### PR TITLE
chore: restrict PR comment of test results to just the parent repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,9 +325,10 @@ jobs:
         continue-on-error: true
 
       - name: Post PR comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const commentPath = 'test-results/pr-comment.md';


### PR DESCRIPTION
# Fix PR Comment Workflow for Forked Repositories

## 📋 Description

This PR fixes the PR comment workflow to handle forked repositories gracefully, preventing "Resource not accessible by integration" errors.

**Changes:**

- Added explicit `github-token` parameter to ensure proper authentication
- Added fork detection to skip PR comments for external contributors
- Prevents permission errors when PRs come from forks

## 🔗 Related Issue

Part of CI/CD improvements for #19 - Test Report Publishing

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Configuration change
- [ ] 🚀 Performance improvement

## 🧪 Testing

### Manual Verification

**CI/CD Workflow:**

- [x] Verified PR comments work for same-repository PRs
- [x] Confirmed fork detection skips PR comments appropriately
- [x] Tested explicit github-token parameter resolves auth issues
- [x] Validated workflow passes all checks

### Test Commands Run

```bash
# Verified linting works
npm run lint

# Verified tests still pass
npm test
```

## 📦 Files Changed

### Modified Files

**`.github/workflows/ci.yml`:**

- Line 330: Added explicit `github-token: ${{ secrets.GITHUB_TOKEN }}`
- Line 329: Added fork detection condition: `github.event.pull_request.head.repo.full_name == github.repository`
- Prevents "Resource not accessible by integration" errors on forked PRs

## 🔧 CI/CD Changes Explained

### Problem

PR comments were failing with "Resource not accessible by integration" error when:

1. The workflow didn't have explicit github-token
2. PRs from forked repositories tried to write comments (security restriction)

### Solution

**1. Explicit Token:**

```yaml
github-token: ${{ secrets.GITHUB_TOKEN }}
```

Ensures the action has proper authentication with the permissions defined at the job level.

**2. Fork Detection:**

```yaml
if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```

Skips PR comment step when `head.repo` (source) doesn't match `repository` (target), indicating a forked PR.

**Why this matters:**

- Same-repo PRs: ✅ Get automated test result comments
- Forked PRs: ⏭️ Skip comment step (prevents permission errors)
- Security: ✅ No elevated permissions for external contributors
  "testing.automaticallyOpenPeekView": "never"

````

**Why:** Prevents VS Code from automatically opening test results panel. Users can open it manually if desired.

### 9. Debug Configuration ⭐ **NEW**

```json
```yaml
github-token: ${{ secrets.GITHUB_TOKEN }}
```
Ensures the action has proper authentication with the permissions defined at the job level.

**2. Fork Detection:**
```yaml
if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```
Skips PR comment step when `head.repo` (source) doesn't match `repository` (target), indicating a forked PR.

**Why this matters:**
- Same-repo PRs: ✅ Get automated test result comments
- Forked PRs: ⏭️ Skip comment step (prevents permission errors)
- Security: ✅ No elevated permissions for external contributors

### Before This PR
```yaml
if: always() && github.event_name == 'pull_request'
```
❌ Tried to comment on ALL PRs (including forks) → Permission error

### After This PR
```yaml
if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```
✅ Only comments on same-repository PRs → No errors

**Why forks need special handling:**
- GitHub restricts write permissions for PRs from forks (security)
- `GITHUB_TOKEN` for forked PRs has read-only access
- Attempting to write comments → "Resource not accessible by integration" error

**Result:**
- Same-repo PRs: Get automated test comments ✅
- Forked PRs: Tests run, but no comment (gracefully skipped) ⏭️

## ✅ Checklist

- [x] My code follows the project's naming conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for my commit messages

## 🔍 Reviewer Notes

### Testing This PR

**CI/CD Workflow:**
1. Check the workflow file changes are minimal (2 lines modified)
2. Verify condition logic makes sense: `head.repo.full_name == repository`
3. Confirm PR comments still work for same-repo PRs in CI logs

### Areas to Review

1. **Condition Logic** - Does the fork detection condition work correctly?
2. **Token Usage** - Is the explicit github-token parameter necessary?
3. **Error Handling** - Are permission errors properly prevented?

### Questions for Reviewers

- Are there any settings that should be user-specific instead?
- Should we add any additional workspace settings?
- Are the Auto Attach and format-on-save settings appropriate defaults?

---

**Before submitting this PR, please ensure:**

1. ✅ You have reviewed the [Branching Strategy](docs/BRANCHING-STRATEGY.md)
2. ✅ You have followed the [Pull Request Guidelines](docs/PULL-REQUEST.md)
3. ✅ Your branch is up to date with the base branch
````
